### PR TITLE
/scripts/deploy.ah: Fixes .deb file not found error

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,8 +14,8 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
   # Clone the repository in the buildApk folder
   git clone --quiet --branch=deb https://abishekvashok:$GITHUB_API_KEY@github.com/fossasia/meilix-artwork deb > /dev/null
 
-  cp -Rf $HOME/plymouth-meilix-logo_1.0-1_all.deb deb/
-  cp -Rf $HOME/plymouth-meilix-text_1.0-1_all.deb deb/
+  cp -Rf $TRAVIS_BUILD_DIR/plymouth-meilix-logo_1.0-1_all.deb deb/
+  cp -Rf $TRAVIS_BUILD_DIR/plymouth-meilix-text_1.0-1_all.deb deb/
   cd deb
 
   git checkout --orphan workaround


### PR DESCRIPTION
The script assumed that the .Deb files were created in the
home directory, but it is actually created in the repo directory

Fixes #11
Signed-off-by: Abishek V Ashok <abishekvashok@gmail.com>