### PR TITLE
The module name and depency name errors are now resolved for text package- (Solves issue#19)

### DIFF
--- a/meilix-artwork/debian/control
+++ b/meilix-artwork/debian/control
@@ -13,5 +13,5 @@ Description: Plymouth theme meilix.
 
 Package: plymouth-meilix-text
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, plymouth, plymouth-label
+Depends: ${shlibs:Depends}, ${misc:Depends}, plymouth, plymouth-label, plymouth-theme-ubuntu-text
 Description: Plymouth theme meilix.

--- a/meilix-artwork/usr/share/plymouth/themes/meilix-text/meilix-text.plymouth
+++ b/meilix-artwork/usr/share/plymouth/themes/meilix-text/meilix-text.plymouth
@@ -1,7 +1,7 @@
 [Plymouth Theme]
 Name=Meilix Text
 Description=Text mode plymouth theme for Meilix
-ModuleName=meilix-text
+ModuleName=ubuntu-text
 
 [ubuntu-text]
 title=Meilix


### PR DESCRIPTION
Fixes #19 

 - Short description of what this resolves:
    The error `64 bit issue /usr/lib/x86_64-linux-gnu/plymouth//meilix-text.so`  error is now resolved 

 - Changes proposed in this pull request:

1.  `plymouth-theme-ubuntu-text` dependency is added
2. `meilix-text` is now renamed to `ubuntu-text` (meilix-text was causing the error)

Screenshot of reboot:
![meilix](https://user-images.githubusercontent.com/34754265/47743006-f7349b00-dca3-11e8-92eb-78ea06281990.gif)
Note: this GIF is just for test
   


