### PR TITLE
Changed standard version for lintian warning- (Solves -#43)

### DIFF
--- a/meilix-artwork/debian/control
+++ b/meilix-artwork/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: extra
 Maintainer: Mario Behling <mb@mariobehling.de>
 Build-Depends: debhelper (>= 8.0.0), python(>=2.6)
-Standards-Version: 3.9.2
+Standards-Version: 4.1.3
 Homepage: http://mbm.vn
 
 Package: plymouth-theme-meilix-logo


### PR DESCRIPTION
Fixes #43 

 - Short description of what this resolves:
   The ancient version was not updated for the current debian policy

    
- Changes proposed in this pull request:
   Updated debian version for the packages
